### PR TITLE
Fix typo in main scene file

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ def init_game():
 
 	# load host scene
 	Main.scene = hg.Scene()
-	hg.LoadSceneFromAssets("pool/pool_Main_scene.scn", Main.scene, Main.pipeline_res, hg.GetForwardPipelineInfo())
+	hg.LoadSceneFromAssets("pool/pool_main_scene.scn", Main.scene, Main.pipeline_res, hg.GetForwardPipelineInfo())
 	Main.balls.append(Main.scene.GetNode("ball_red"))
 	Main.balls.append(Main.scene.GetNode("ball_white"))
 	Main.balls.append(Main.scene.GetNode("ball_yellow"))


### PR DESCRIPTION
Running the project on a linux machine results in the following error:

`main.py:148: Warning: Failed to open asset 'pool/pool_Main_scene.scn' (file not found)`

This was perhaps not seen, if development and qualification was performed on windows.